### PR TITLE
feat: add AI chat replies

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@
 - Reacts to certain keywords
 - Self promotion (of my youtube channel) 😎
 - Bruhngus
+- AI replies via an OpenAI-compatible API when Tob is tagged with `@tob <query>`
 
 ## Running the bot
-You will need to setup a discord bot, a twitter application, and get the correct tokens from those setup as environment variables (refer to `src/main.py` for the environment variables needed).
+You will need to setup a discord bot, a twitter application, and get the correct tokens from those setup as environment variables (refer to `src/main.py` for the environment variables needed). Set `OPENAI_API_KEY` to enable AI replies; `OPENAI_BASE_URL` and `OPENAI_MODEL` are optional.
 
 (For access to the running instance of the bot, please DM me on discord at `Sol_InvictusXLII#1306`).
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 - AI replies via an OpenAI-compatible API when Tob is tagged with `@tob <query>`
 
 ## Running the bot
-You will need to setup a discord bot, a twitter application, and get the correct tokens from those setup as environment variables (refer to `src/main.py` for the environment variables needed). Set `OPENAI_API_KEY` to enable AI replies; `OPENAI_BASE_URL` and `OPENAI_MODEL` are optional.
+You will need to setup a discord bot, a twitter application, and get the correct tokens from those setup as environment variables (refer to `src/main.py` for the environment variables needed). Set `OPENAI_API_KEY` to enable AI replies; `OPENAI_BASE_URL` and `OPENAI_MODEL` are optional. Set `OPENAI_WEB_SEARCH=true` with OpenRouter to allow Tob to browse the web via OpenRouter's `openrouter:web_search` server tool.
 
 (For access to the running instance of the bot, please DM me on discord at `Sol_InvictusXLII#1306`).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ keywords = ["discord", "bot"]
 
 [tool.poetry.dependencies]
 python = "^3.10"
+aiohttp = "^3.9.0"
 colorama = "^0.4.5"
 discord = "^2.0.0"
 python-dotenv = "^0.21.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+aiohttp       == 3.9.*
 colorama      == 0.4.*
 discord       == 2.3.*
 python_dotenv == 1.0.*

--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+import os
+
 from dotenv import load_dotenv
 
 from tob import Tob
@@ -18,6 +20,9 @@ def main():
     env_arg(args, "REPLY_TO_INVALID_COMMAND", "reply_to_invalid_command", default=False)
     env_arg(args, "LOG_COLOR", "log_color", default=False)
     env_arg(args, "CLEAR_CACHE", "clear_cache", default=False)
+    args["openai_api_key"] = os.getenv("OPENAI_API_KEY")
+    env_arg(args, "OPENAI_BASE_URL", "openai_base_url", default="https://api.openai.com/v1")
+    env_arg(args, "OPENAI_MODEL", "openai_model", default="gpt-4o-mini")
 
     tob = Tob(**args)
     tob.run(bot_token)

--- a/src/main.py
+++ b/src/main.py
@@ -6,7 +6,7 @@ import os
 from dotenv import load_dotenv
 
 from tob import Tob
-from utils.utils import env, env_arg
+from utils.utils import env, env_arg, to_bool
 from typing import Any
 
 
@@ -23,6 +23,7 @@ def main():
     args["openai_api_key"] = os.getenv("OPENAI_API_KEY")
     env_arg(args, "OPENAI_BASE_URL", "openai_base_url", default="https://api.openai.com/v1")
     env_arg(args, "OPENAI_MODEL", "openai_model", default="gpt-4o-mini")
+    args["openai_web_search"] = to_bool(os.getenv("OPENAI_WEB_SEARCH", False))
 
     tob = Tob(**args)
     tob.run(bot_token)

--- a/src/tob.py
+++ b/src/tob.py
@@ -7,6 +7,7 @@ from timeit import default_timer as timer
 from typing import Any, Callable, TypedDict
 
 from datetime import datetime
+import aiohttp
 import discord
 
 from utils.log import log
@@ -55,6 +56,9 @@ URL_REGEX = re.compile(
     re.I | re.M,
 )
 
+AI_TRIGGER = "@tob "
+AI_SYSTEM_PROMPT = "You're Tob, a friendly AI chatbot embedded in a Discord server."
+
 # ---------------------------------------------- Tob --------------------------------------------- #
 
 
@@ -85,6 +89,10 @@ class Tob(discord.Client):
     reply_to_invalid_command: bool
     # Whether to clear cache on exit
     clear_cache: bool
+    # OpenAI-compatible API settings
+    openai_api_key: str | None
+    openai_base_url: str
+    openai_model: str
     # Contains blocked channels, cache etc
     data: Any = INIT_DATA
     failed_loading_data: bool = False
@@ -99,6 +107,9 @@ class Tob(discord.Client):
         test: bool = False,
         reply_to_invalid_command: bool = False,
         clear_cache: bool = False,
+        openai_api_key: str | None = None,
+        openai_base_url: str = "https://api.openai.com/v1",
+        openai_model: str = "gpt-4o-mini",
     ) -> None:
         intents = discord.Intents().default()
         intents.message_content = True
@@ -113,6 +124,9 @@ class Tob(discord.Client):
         self.test = test
         self.reply_to_invalid_command = reply_to_invalid_command
         self.clear_cache = clear_cache
+        self.openai_api_key = openai_api_key
+        self.openai_base_url = openai_base_url.rstrip("/")
+        self.openai_model = openai_model
 
         self._loadData()
         self._setSeed()
@@ -149,6 +163,12 @@ class Tob(discord.Client):
                 if await_responses := self._handle_command(msg, text, ch_id, g_id):
                     for x in await_responses:
                         await x[0](**x[1])
+                return
+
+            # AI chat
+            if query := self._get_ai_query(msg, text):
+                log.debug(f"AI: {format_msg_full(msg)}", "on_message::ai")
+                await msg.reply(await self._get_ai_reply(query), mention_author=False)
                 return
 
             # Replace twitter.com and/or media.discordapp.net
@@ -598,6 +618,45 @@ class Tob(discord.Client):
             self.data["guilds"].remove(guild_id)
         self._save()
         return ret
+
+    def _get_ai_query(self, msg: discord.Message, text: str) -> str | None:
+        query = None
+        if text.lower().startswith(AI_TRIGGER):
+            query = text[len(AI_TRIGGER) :]
+        elif self.user:
+            for mention in (f"<@{self.user.id}> ", f"<@!{self.user.id}> "):
+                if text.startswith(mention):
+                    query = text[len(mention) :]
+                    break
+
+        if query is None or not query.strip():
+            return None
+        if not self.test and self.user and self.user not in getattr(msg, "mentions", []):
+            return None
+        return query.strip()
+
+    async def _get_ai_reply(self, query: str) -> str:
+        if not self.openai_api_key:
+            return "AI is not configured."
+
+        payload = {
+            "model": self.openai_model,
+            "messages": [
+                {"role": "system", "content": AI_SYSTEM_PROMPT},
+                {"role": "user", "content": query},
+            ],
+        }
+        headers = {"Authorization": f"Bearer {self.openai_api_key}"}
+        url = f"{self.openai_base_url}/chat/completions"
+
+        async with aiohttp.ClientSession() as session:
+            async with session.post(url, json=payload, headers=headers) as response:
+                if response.status >= 400:
+                    log.warn(await response.text(), "on_message::ai")
+                    return "AI request failed."
+                data = await response.json()
+
+        return data["choices"][0]["message"]["content"].strip()
 
     def _valid_message(self, msg: discord.Message) -> bool:
         ch_id = str(msg.channel.id)

--- a/src/tob.py
+++ b/src/tob.py
@@ -93,6 +93,7 @@ class Tob(discord.Client):
     openai_api_key: str | None
     openai_base_url: str
     openai_model: str
+    openai_web_search: bool
     # Contains blocked channels, cache etc
     data: Any = INIT_DATA
     failed_loading_data: bool = False
@@ -110,6 +111,7 @@ class Tob(discord.Client):
         openai_api_key: str | None = None,
         openai_base_url: str = "https://api.openai.com/v1",
         openai_model: str = "gpt-4o-mini",
+        openai_web_search: bool = False,
     ) -> None:
         intents = discord.Intents().default()
         intents.message_content = True
@@ -127,6 +129,7 @@ class Tob(discord.Client):
         self.openai_api_key = openai_api_key
         self.openai_base_url = openai_base_url.rstrip("/")
         self.openai_model = openai_model
+        self.openai_web_search = openai_web_search
 
         self._loadData()
         self._setSeed()
@@ -646,6 +649,9 @@ class Tob(discord.Client):
                 {"role": "user", "content": query},
             ],
         }
+        if self.openai_web_search:
+            payload["tools"] = [{"type": "openrouter:web_search"}]
+
         headers = {"Authorization": f"Bearer {self.openai_api_key}"}
         url = f"{self.openai_base_url}/chat/completions"
 

--- a/tests/local_ai_openrouter.py
+++ b/tests/local_ai_openrouter.py
@@ -12,16 +12,17 @@ def _openrouter_key() -> str:
     return Path("~/.openrouter").expanduser().read_text().strip()
 
 
-def _client(model: str = "openrouter/free") -> SimpleNamespace:
+def _client(model: str = "openrouter/free", web_search: bool = False) -> SimpleNamespace:
     return SimpleNamespace(
         openai_api_key=_openrouter_key(),
         openai_base_url="https://openrouter.ai/api/v1",
         openai_model=model,
+        openai_web_search=web_search,
     )
 
 
-def _reply(prompt: str, model: str = "openrouter/free") -> str:
-    return asyncio.run(Tob._get_ai_reply(_client(model), prompt))
+def _reply(prompt: str, model: str = "openrouter/free", web_search: bool = False) -> str:
+    return asyncio.run(Tob._get_ai_reply(_client(model, web_search), prompt))
 
 
 def test_openrouter_free_can_reply():
@@ -30,8 +31,8 @@ def test_openrouter_free_can_reply():
 
 def test_openrouter_free_web_browsing_probe():
     reply = _reply(
-        "Can you browse live web pages in this chat completion request? "
-        "Answer with one short sentence."
+        "What is the title of https://example.com/? Answer briefly and cite the source.",
+        web_search=True,
     )
     print(reply)
-    assert reply
+    assert "Example Domain" in reply

--- a/tests/local_ai_openrouter.py
+++ b/tests/local_ai_openrouter.py
@@ -1,0 +1,37 @@
+import asyncio
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+from src.tob import Tob
+
+
+def _openrouter_key() -> str:
+    if key := os.getenv("OPENROUTER_API_KEY"):
+        return key
+    return Path("~/.openrouter").expanduser().read_text().strip()
+
+
+def _client(model: str = "openrouter/free") -> SimpleNamespace:
+    return SimpleNamespace(
+        openai_api_key=_openrouter_key(),
+        openai_base_url="https://openrouter.ai/api/v1",
+        openai_model=model,
+    )
+
+
+def _reply(prompt: str, model: str = "openrouter/free") -> str:
+    return asyncio.run(Tob._get_ai_reply(_client(model), prompt))
+
+
+def test_openrouter_free_can_reply():
+    assert _reply("Reply with exactly: tob ok") == "tob ok"
+
+
+def test_openrouter_free_web_browsing_probe():
+    reply = _reply(
+        "Can you browse live web pages in this chat completion request? "
+        "Answer with one short sentence."
+    )
+    print(reply)
+    assert reply


### PR DESCRIPTION
Adds an OpenAI-compatible chat completion path that responds when Tob is tagged with a non-empty `@tob <query>` prompt. The request includes a system prompt identifying Tob as a friendly AI chatbot embedded in a Discord server, and the API key/base URL/model are configurable through environment variables.

The feature was also checked locally against OpenRouter using the free router model.
