### PR TITLE
fix: format AI context messages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,6 @@ CLEAR_CACHE=True
 # AI
 ENABLE_AI=False
 OPENAI_API_KEY=
-OPENAI_BASE_URL=https://api.openai.com/v1
-OPENAI_MODEL=gpt-4o-mini
-OPENAI_WEB_SEARCH=False
+OPENAI_BASE_URL=https://openrouter.ai/api/v1
+OPENAI_MODEL=openai/gpt-5-nano
+OPENAI_WEB_SEARCH=True

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 - AI replies via an OpenAI-compatible API when Tob is tagged with `@tob <query>`
 
 ## Running the bot
-You will need to setup a discord bot, a twitter application, and get the correct tokens from those setup as environment variables (refer to `src/main.py` for the environment variables needed). Set `ENABLE_AI=true` and `OPENAI_API_KEY` to enable AI replies; `OPENAI_BASE_URL` and `OPENAI_MODEL` are optional. Set `OPENAI_WEB_SEARCH=true` with OpenRouter to allow Tob to browse the web via OpenRouter's `openrouter:web_search` server tool.
+You will need to setup a discord bot, a twitter application, and get the correct tokens from those setup as environment variables (refer to `src/main.py` for the environment variables needed). Set `ENABLE_AI=true` and `OPENAI_API_KEY` to enable AI replies. The example config uses OpenRouter with `openai/gpt-5-nano`; set `OPENAI_WEB_SEARCH=true` to allow Tob to browse the web via OpenRouter's `openrouter:web_search` server tool.
 
 (For access to the running instance of the bot, please DM me on discord at `Sol_InvictusXLII#1306`).
 

--- a/src/tob.py
+++ b/src/tob.py
@@ -1,5 +1,6 @@
 from os.path import exists
 import asyncio
+import html
 import json
 import random
 import re
@@ -144,7 +145,7 @@ class Tob(discord.Client):
     # Contains blocked channels, cache etc
     data: Any = INIT_DATA
     failed_loading_data: bool = False
-    ai_message_context: list[tuple[float, str, int, str, str]]
+    ai_message_context: list[tuple[float, str, int, str, str, str, str]]
     active_messages: int
     shutting_down: bool
     shutdown_waiter: asyncio.Event | None
@@ -784,18 +785,30 @@ class Tob(discord.Client):
                 return None
         return query.strip()
 
-    def _format_ai_author(self, author: Any) -> str:
-        username = str(author)
-        display_name = getattr(author, "display_name", None)
+    def _format_ai_author(self, author: Any, include_extra: bool = True) -> str:
+        _, display_name, extra = self._get_ai_author_info(author)
+        if include_extra and extra:
+            return f"{display_name} ({extra})"
+        return display_name
+
+    def _get_ai_author_info(self, author: Any) -> tuple[str, str, str]:
         user_id = getattr(author, "id", None)
-        suffix = f" id={user_id}" if user_id else ""
-        if display_name and display_name != username:
-            return f"{username} ({display_name}{suffix})"
-        return f"{username} ({suffix.lstrip()})" if suffix else username
+        username = self._strip_discriminator(getattr(author, "name", None) or str(author))
+        display_name = self._strip_discriminator(getattr(author, "display_name", None) or username)
+        key = str(user_id) if user_id else display_name
+        extras = []
+        if username != display_name:
+            extras.append(username)
+        if user_id:
+            extras.append(f"id={user_id}")
+        return key, display_name, " ".join(extras)
+
+    def _strip_discriminator(self, name: str) -> str:
+        return re.sub(r"#\d{4}$", "", name)
 
     def _format_ai_text(self, msg: discord.Message, text: str) -> str:
         for user in getattr(msg, "mentions", []):
-            author = self._format_ai_author(user)
+            author = self._format_ai_author(user, include_extra=False)
             text = text.replace(f"<@{user.id}>", f"@{author}")
             text = text.replace(f"<@!{user.id}>", f"@{author}")
         for channel in getattr(msg, "channel_mentions", []):
@@ -846,7 +859,7 @@ class Tob(discord.Client):
                 timer(),
                 ch_id,
                 msg.id,
-                self._format_ai_author(msg.author),
+                *self._get_ai_author_info(msg.author),
                 self._format_ai_text(msg, text),
             )
         )
@@ -864,7 +877,7 @@ class Tob(discord.Client):
         if len(context) < AI_CONTEXT_MAX_MESSAGES:
             context = await self._fetch_ai_context(msg, ch_id, context)
         context = context[-AI_CONTEXT_MAX_MESSAGES:]
-        messages = "\n".join(f"{author}: {content}" for _, _, _, author, content in context)
+        messages = self._format_ai_context_messages(context)
         return f"""<context>
 <metadata>
 current_time: {datetime.now(timezone.utc).isoformat()}
@@ -879,19 +892,38 @@ harness_will_reverse_output: {str(harness_will_reverse_output).lower()}
 </messages>
 </context>"""
 
+    def _format_ai_context_messages(
+        self, context: list[tuple[float, str, int, str, str, str, str]]
+    ) -> str:
+        seen_authors = set()
+        messages = []
+        for _, _, message_id, author_key, display_name, extra, content in context:
+            include_extra = author_key not in seen_authors
+            seen_authors.add(author_key)
+            author = display_name
+            if include_extra and extra:
+                author = f"{display_name} ({extra})"
+            messages.append(
+                f'<message id="{html.escape(str(message_id), quote=True)}" '
+                f'author="{html.escape(author, quote=True)}">\n'
+                f"{html.escape(content)}\n"
+                f"</message>"
+            )
+        return "\n".join(messages)
+
     async def _fetch_ai_context(
         self,
         msg: discord.Message,
         ch_id: str,
-        context: list[tuple[float, str, int, str, str]],
-    ) -> list[tuple[float, str, int, str, str]]:
+        context: list[tuple[float, str, int, str, str, str, str]],
+    ) -> list[tuple[float, str, int, str, str, str, str]]:
         history = getattr(msg.channel, "history", None)
         if not history:
             return context
 
         min_created_at = datetime.now(timezone.utc).timestamp() - AI_CONTEXT_MAX_AGE_SECONDS
         seen = {x[2] for x in context}
-        fetched: list[tuple[float, str, int, str, str]] = []
+        fetched: list[tuple[float, str, int, str, str, str, str]] = []
         try:
             async for old_msg in history(limit=AI_CONTEXT_MAX_MESSAGES, before=msg):
                 created_at = old_msg.created_at.replace(tzinfo=timezone.utc).timestamp()
@@ -904,7 +936,7 @@ harness_will_reverse_output: {str(harness_will_reverse_output).lower()}
                         timer(),
                         ch_id,
                         old_msg.id,
-                        self._format_ai_author(old_msg.author),
+                        *self._get_ai_author_info(old_msg.author),
                         self._format_ai_text(old_msg, old_msg.content),
                     )
                 )

--- a/src/tob.py
+++ b/src/tob.py
@@ -1,5 +1,6 @@
 from os.path import exists
 import asyncio
+from dataclasses import dataclass
 import html
 import json
 import random
@@ -120,6 +121,17 @@ class InvalidCommandError(Exception):
     pass
 
 
+@dataclass
+class AiContextMessage:
+    created_at: float
+    channel_id: str
+    message_id: int
+    author_key: str
+    display_name: str
+    author_extra: str
+    content: str
+
+
 class Tob(discord.Client):
     # TODO: Docsify this to __init__ (also these are not class variables)
     # Start time, to time ready seconds
@@ -145,7 +157,7 @@ class Tob(discord.Client):
     # Contains blocked channels, cache etc
     data: Any = INIT_DATA
     failed_loading_data: bool = False
-    ai_message_context: list[tuple[float, str, int, str, str, str, str]]
+    ai_message_context: list[AiContextMessage]
     active_messages: int
     shutting_down: bool
     shutdown_waiter: asyncio.Event | None
@@ -867,47 +879,49 @@ class Tob(discord.Client):
         return f"{name} id={guild_id}" if guild_id else str(name)
 
     def _record_ai_context(self, msg: discord.Message, text: str, ch_id: str) -> None:
-        if any(x[2] == msg.id for x in self.ai_message_context):
+        if any(x.message_id == msg.id for x in self.ai_message_context):
             return
+        author_key, display_name, author_extra = self._get_ai_author_info(msg.author)
         self.ai_message_context.append(
-            (
-                timer(),
-                ch_id,
-                msg.id,
-                *self._get_ai_author_info(msg.author),
-                self._format_ai_text(msg, text),
+            AiContextMessage(
+                created_at=timer(),
+                channel_id=ch_id,
+                message_id=msg.id,
+                author_key=author_key,
+                display_name=display_name,
+                author_extra=author_extra,
+                content=self._format_ai_text(msg, text),
             )
         )
         self._prune_ai_context()
 
     def _update_ai_context_message(self, msg: discord.Message, text: str) -> None:
-        for i, context_msg in enumerate(self.ai_message_context):
-            created_at, ch_id, msg_id, *_ = context_msg
-            if msg_id == msg.id:
-                self.ai_message_context[i] = (
-                    created_at,
-                    ch_id,
-                    msg.id,
-                    *self._get_ai_author_info(msg.author),
-                    self._format_ai_text(msg, text),
-                )
+        for context_msg in self.ai_message_context:
+            if context_msg.message_id == msg.id:
+                author_key, display_name, author_extra = self._get_ai_author_info(msg.author)
+                context_msg.author_key = author_key
+                context_msg.display_name = display_name
+                context_msg.author_extra = author_extra
+                context_msg.content = self._format_ai_text(msg, text)
                 return
 
     def _remove_ai_context_message(self, msg_id: int) -> None:
-        self.ai_message_context = [x for x in self.ai_message_context if x[2] != msg_id]
+        self.ai_message_context = [x for x in self.ai_message_context if x.message_id != msg_id]
 
     def _remove_ai_context_messages(self, msg_ids: set[int]) -> None:
-        self.ai_message_context = [x for x in self.ai_message_context if x[2] not in msg_ids]
+        self.ai_message_context = [
+            x for x in self.ai_message_context if x.message_id not in msg_ids
+        ]
 
     def _prune_ai_context(self) -> None:
         min_time = timer() - AI_CONTEXT_MAX_AGE_SECONDS
-        self.ai_message_context = [x for x in self.ai_message_context if x[0] >= min_time]
+        self.ai_message_context = [x for x in self.ai_message_context if x.created_at >= min_time]
 
     async def _get_ai_context(
         self, msg: discord.Message, ch_id: str, harness_will_reverse_output: bool = False
     ) -> str:
         self._prune_ai_context()
-        context = [x for x in self.ai_message_context if x[1] == ch_id]
+        context = [x for x in self.ai_message_context if x.channel_id == ch_id]
         if len(context) < AI_CONTEXT_MAX_MESSAGES:
             context = await self._fetch_ai_context(msg, ch_id, context)
         context = context[-AI_CONTEXT_MAX_MESSAGES:]
@@ -926,21 +940,19 @@ harness_will_reverse_output: {str(harness_will_reverse_output).lower()}
 </messages>
 </context>"""
 
-    def _format_ai_context_messages(
-        self, context: list[tuple[float, str, int, str, str, str, str]]
-    ) -> str:
+    def _format_ai_context_messages(self, context: list[AiContextMessage]) -> str:
         seen_authors = set()
         messages = []
-        for _, _, message_id, author_key, display_name, extra, content in context:
-            include_extra = author_key not in seen_authors
-            seen_authors.add(author_key)
-            author = display_name
-            if include_extra and extra:
-                author = f"{display_name} ({extra})"
+        for context_msg in context:
+            include_extra = context_msg.author_key not in seen_authors
+            seen_authors.add(context_msg.author_key)
+            author = context_msg.display_name
+            if include_extra and context_msg.author_extra:
+                author = f"{context_msg.display_name} ({context_msg.author_extra})"
             messages.append(
-                f'<message id="{html.escape(str(message_id), quote=True)}" '
+                f'<message id="{html.escape(str(context_msg.message_id), quote=True)}" '
                 f'author="{html.escape(author, quote=True)}">\n'
-                f"{html.escape(content)}\n"
+                f"{html.escape(context_msg.content)}\n"
                 f"</message>"
             )
         return "\n".join(messages)
@@ -949,15 +961,15 @@ harness_will_reverse_output: {str(harness_will_reverse_output).lower()}
         self,
         msg: discord.Message,
         ch_id: str,
-        context: list[tuple[float, str, int, str, str, str, str]],
-    ) -> list[tuple[float, str, int, str, str, str, str]]:
+        context: list[AiContextMessage],
+    ) -> list[AiContextMessage]:
         history = getattr(msg.channel, "history", None)
         if not history:
             return context
 
         min_created_at = datetime.now(timezone.utc).timestamp() - AI_CONTEXT_MAX_AGE_SECONDS
-        seen = {x[2] for x in context}
-        fetched: list[tuple[float, str, int, str, str, str, str]] = []
+        seen = {x.message_id for x in context}
+        fetched: list[AiContextMessage] = []
         try:
             async for old_msg in history(limit=AI_CONTEXT_MAX_MESSAGES, before=msg):
                 created_at = old_msg.created_at.replace(tzinfo=timezone.utc).timestamp()
@@ -965,13 +977,16 @@ harness_will_reverse_output: {str(harness_will_reverse_output).lower()}
                     break
                 if old_msg.id in seen or not old_msg.content:
                     continue
+                author_key, display_name, author_extra = self._get_ai_author_info(old_msg.author)
                 fetched.append(
-                    (
-                        timer(),
-                        ch_id,
-                        old_msg.id,
-                        *self._get_ai_author_info(old_msg.author),
-                        self._format_ai_text(old_msg, old_msg.content),
+                    AiContextMessage(
+                        created_at=timer(),
+                        channel_id=ch_id,
+                        message_id=old_msg.id,
+                        author_key=author_key,
+                        display_name=display_name,
+                        author_extra=author_extra,
+                        content=self._format_ai_text(old_msg, old_msg.content),
                     )
                 )
         except (discord.Forbidden, discord.HTTPException) as e:

--- a/src/tob.py
+++ b/src/tob.py
@@ -196,6 +196,9 @@ class Tob(discord.Client):
             # Register event handlers
             self.event(self.on_ready)
             self.event(self.on_message)
+            self.event(self.on_message_edit)
+            self.event(self.on_raw_message_delete)
+            self.event(self.on_raw_bulk_message_delete)
             signal.signal(signal.SIGINT, self._handle_ctrlc)  # type: ignore
 
     # -------------------------------------- Event Handlers -------------------------------------- #
@@ -204,6 +207,18 @@ class Tob(discord.Client):
         elapsed = timer() - self.start_time
         log.info("Ready after:  {:.3f}s".format(elapsed), "on_ready")
         log.info(f"Logged in as: {self.user}", "on_ready")
+
+    async def on_message_edit(self, before: discord.Message, after: discord.Message) -> None:
+        if not after.content:
+            self._remove_ai_context_message(after.id)
+            return
+        self._update_ai_context_message(after, after.content)
+
+    async def on_raw_message_delete(self, payload: discord.RawMessageDeleteEvent) -> None:
+        self._remove_ai_context_message(payload.message_id)
+
+    async def on_raw_bulk_message_delete(self, payload: discord.RawBulkMessageDeleteEvent) -> None:
+        self._remove_ai_context_messages(payload.message_ids)
 
     async def on_message(self, msg: discord.Message) -> None:
         # Dont respond to no message content
@@ -864,6 +879,25 @@ class Tob(discord.Client):
             )
         )
         self._prune_ai_context()
+
+    def _update_ai_context_message(self, msg: discord.Message, text: str) -> None:
+        for i, context_msg in enumerate(self.ai_message_context):
+            created_at, ch_id, msg_id, *_ = context_msg
+            if msg_id == msg.id:
+                self.ai_message_context[i] = (
+                    created_at,
+                    ch_id,
+                    msg.id,
+                    *self._get_ai_author_info(msg.author),
+                    self._format_ai_text(msg, text),
+                )
+                return
+
+    def _remove_ai_context_message(self, msg_id: int) -> None:
+        self.ai_message_context = [x for x in self.ai_message_context if x[2] != msg_id]
+
+    def _remove_ai_context_messages(self, msg_ids: set[int]) -> None:
+        self.ai_message_context = [x for x in self.ai_message_context if x[2] not in msg_ids]
 
     def _prune_ai_context(self) -> None:
         min_time = timer() - AI_CONTEXT_MAX_AGE_SECONDS

--- a/src/tob.py
+++ b/src/tob.py
@@ -289,6 +289,7 @@ class Tob(discord.Client):
                             self._format_ai_author(msg.author),
                             ai_context,
                             reverse_reply,
+                            self._get_ai_session_id(ch_id),
                         )
                         if reverse_reply and reply != AI_REQUEST_FAILED:
                             reply = fullreverse(reply)
@@ -998,6 +999,7 @@ channel: {self._format_ai_channel(msg.channel)}
         author: str = "",
         context: str = "",
         harness_will_reverse_output: bool = False,
+        session_id: str | None = None,
     ) -> str:
         content = self._format_ai_request_content(
             query, author, context, harness_will_reverse_output
@@ -1010,6 +1012,8 @@ channel: {self._format_ai_channel(msg.channel)}
                 {"role": "user", "content": content},
             ],
         }
+        if session_id:
+            payload["session_id"] = session_id[:256]
         headers = {
             "Authorization": f"Bearer {self.openai_api_key}",
             "HTTP-Referer": "https://github.com/Anurag-Shah/TobEgassem",
@@ -1037,6 +1041,9 @@ channel: {self._format_ai_channel(msg.channel)}
                 await asyncio.sleep(delay)
 
         return AI_REQUEST_FAILED
+
+    def _get_ai_session_id(self, ch_id: str) -> str:
+        return f"discord-channel-{ch_id}"[:256]
 
     def _format_ai_request_content(
         self,

--- a/src/tob.py
+++ b/src/tob.py
@@ -927,15 +927,15 @@ class Tob(discord.Client):
         context = context[-AI_CONTEXT_MAX_MESSAGES:]
         messages = self._format_ai_context_messages(context)
         return f"""<context>
-<messages>
-{messages}
-</messages>
-
 <metadata>
 self: {self._format_ai_author(self.user)}
 server: {self._format_ai_guild(msg.guild)}
 channel: {self._format_ai_channel(msg.channel)}
 </metadata>
+
+<messages>
+{messages}
+</messages>
 </context>"""
 
     def _format_ai_context_messages(self, context: list[AiContextMessage]) -> str:
@@ -1090,12 +1090,31 @@ harness_will_reverse_output: {str(harness_will_reverse_output).lower()}
             log.warn(f"AI response was not JSON: {text}", "on_message::ai")
             return None, None
 
+        self._log_ai_usage(data)
         reply = self._extract_ai_reply(data)
         if reply:
             return reply, None
 
         log.warn(f"AI response missing content: {text}", "on_message::ai")
         return None, self._parse_ai_retry_after(text)
+
+    def _log_ai_usage(self, data: Any) -> None:
+        if not isinstance(data, dict):
+            return
+        usage = data.get("usage")
+        if not isinstance(usage, dict):
+            return
+        details = usage.get("prompt_tokens_details")
+        if not isinstance(details, dict):
+            return
+        cached_tokens = details.get("cached_tokens")
+        cache_write_tokens = details.get("cache_write_tokens")
+        if cached_tokens or cache_write_tokens:
+            log.debug(
+                f"AI cache usage: cached_tokens={cached_tokens or 0} "
+                f"cache_write_tokens={cache_write_tokens or 0}",
+                "on_message::ai",
+            )
 
     def _extract_ai_reply(self, data: Any) -> str | None:
         if not isinstance(data, dict):

--- a/src/tob.py
+++ b/src/tob.py
@@ -281,13 +281,14 @@ class Tob(discord.Client):
                 log.debug(f"AI: {format_msg_full(msg)}", "on_message::ai")
                 try:
                     reverse_reply = random_chance(self.probability)
-                    ai_context = await self._get_ai_context(msg, ch_id, reverse_reply)
+                    ai_context = await self._get_ai_context(msg, ch_id)
                     self._record_ai_context(msg, text, ch_id)
                     async with msg.channel.typing():
                         reply = await self._get_ai_reply(
                             self._format_ai_text(msg, query),
                             self._format_ai_author(msg.author),
                             ai_context,
+                            reverse_reply,
                         )
                         if reverse_reply and reply != AI_REQUEST_FAILED:
                             reply = fullreverse(reply)
@@ -917,9 +918,7 @@ class Tob(discord.Client):
         min_time = timer() - AI_CONTEXT_MAX_AGE_SECONDS
         self.ai_message_context = [x for x in self.ai_message_context if x.created_at >= min_time]
 
-    async def _get_ai_context(
-        self, msg: discord.Message, ch_id: str, harness_will_reverse_output: bool = False
-    ) -> str:
+    async def _get_ai_context(self, msg: discord.Message, ch_id: str) -> str:
         self._prune_ai_context()
         context = [x for x in self.ai_message_context if x.channel_id == ch_id]
         if len(context) < AI_CONTEXT_MAX_MESSAGES:
@@ -927,17 +926,15 @@ class Tob(discord.Client):
         context = context[-AI_CONTEXT_MAX_MESSAGES:]
         messages = self._format_ai_context_messages(context)
         return f"""<context>
-<metadata>
-current_time: {datetime.now(timezone.utc).isoformat()}
-self: {self._format_ai_author(self.user)}
-server: {self._format_ai_guild(msg.guild)}
-channel: {self._format_ai_channel(msg.channel)}
-harness_will_reverse_output: {str(harness_will_reverse_output).lower()}
-</metadata>
-
 <messages>
 {messages}
 </messages>
+
+<metadata>
+self: {self._format_ai_author(self.user)}
+server: {self._format_ai_guild(msg.guild)}
+channel: {self._format_ai_channel(msg.channel)}
+</metadata>
 </context>"""
 
     def _format_ai_context_messages(self, context: list[AiContextMessage]) -> str:
@@ -995,10 +992,16 @@ harness_will_reverse_output: {str(harness_will_reverse_output).lower()}
 
         return fetched[::-1] + context
 
-    async def _get_ai_reply(self, query: str, author: str = "", context: str = "") -> str:
-        content = f"<query author={author!r}>\n{query}\n</query>"
-        if context:
-            content = f"{context}\n\n{content}"
+    async def _get_ai_reply(
+        self,
+        query: str,
+        author: str = "",
+        context: str = "",
+        harness_will_reverse_output: bool = False,
+    ) -> str:
+        content = self._format_ai_request_content(
+            query, author, context, harness_will_reverse_output
+        )
 
         payload = {
             "model": self.openai_model,
@@ -1034,6 +1037,27 @@ harness_will_reverse_output: {str(harness_will_reverse_output).lower()}
                 await asyncio.sleep(delay)
 
         return AI_REQUEST_FAILED
+
+    def _format_ai_request_content(
+        self,
+        query: str,
+        author: str = "",
+        context: str = "",
+        harness_will_reverse_output: bool = False,
+    ) -> str:
+        request = f"""<request>
+<metadata>
+current_time: {datetime.now(timezone.utc).isoformat()}
+harness_will_reverse_output: {str(harness_will_reverse_output).lower()}
+</metadata>
+
+<query author={author!r}>
+{query}
+</query>
+</request>"""
+        if context:
+            return f"{context}\n\n{request}"
+        return request
 
     async def _request_ai_reply(
         self,

--- a/tests/test_tob.py
+++ b/tests/test_tob.py
@@ -208,6 +208,28 @@ class TestTob:
             self.tob._request_ai_reply = old_request_ai_reply
             self.tob.openai_web_search = old_openai_web_search
 
+    def test_ai_reply_sends_session_id(self):
+        payloads = []
+
+        async def request_ai_reply(_session, _url, payload, _headers):
+            payloads.append(payload)
+            return "ok", None
+
+        old_request_ai_reply = self.tob._request_ai_reply
+        try:
+            self.tob._request_ai_reply = request_ai_reply
+
+            assert (
+                asyncio.run(self.tob._get_ai_reply("hello", session_id="discord-channel-123"))
+                == "ok"
+            )
+            assert payloads[0]["session_id"] == "discord-channel-123"
+        finally:
+            self.tob._request_ai_reply = old_request_ai_reply
+
+    def test_ai_session_id_is_bounded(self):
+        assert len(self.tob._get_ai_session_id("x" * 300)) == 256
+
     def test_ai_reply_missing_choices_returns_error(self, monkeypatch):
         async def request_ai_reply(*_args, **_kwargs):
             return None, None

--- a/tests/test_tob.py
+++ b/tests/test_tob.py
@@ -125,6 +125,36 @@ class TestTob:
         assert '<message id="2" author="display">\nagain\n</message>' in messages
         assert '<message id="3" author="other (id=456)">\nbye\n</message>' in messages
 
+    def test_ai_context_removes_deleted_messages(self):
+        self.tob.ai_message_context = [
+            (1.0, "channel", 1, "author", "author", "", "one"),
+            (2.0, "channel", 2, "author", "author", "", "two"),
+            (3.0, "channel", 3, "author", "author", "", "three"),
+        ]
+
+        self.tob._remove_ai_context_message(2)
+        assert [x[2] for x in self.tob.ai_message_context] == [1, 3]
+
+        self.tob._remove_ai_context_messages({1, 3})
+        assert self.tob.ai_message_context == []
+
+    def test_ai_context_updates_edited_messages(self):
+        class Message:
+            id = 1
+            author = "author"
+            mentions = []
+            channel_mentions = []
+            attachments = []
+            reference = None
+
+        self.tob.ai_message_context = [(1.0, "channel", 1, "author", "author", "", "old")]
+
+        self.tob._update_ai_context_message(Message(), "new <text>")
+
+        assert self.tob.ai_message_context == [
+            (1.0, "channel", 1, "author", "author", "", "new <text>")
+        ]
+
     def test_ai_reply_retries_missing_content(self, monkeypatch):
         calls = 0
 

--- a/tests/test_tob.py
+++ b/tests/test_tob.py
@@ -159,6 +159,21 @@ class TestTob:
             AiContextMessage(1.0, "channel", 1, "author", "author", "", "new <text>")
         ]
 
+    def test_ai_context_places_stable_metadata_before_messages(self):
+        class Message:
+            guild = "guild"
+            channel = "channel"
+
+        self.tob.ai_message_context = [
+            AiContextMessage(1.0, "channel", 1, "author", "author", "", "old")
+        ]
+
+        context = asyncio.run(self.tob._get_ai_context(Message(), "channel"))
+
+        assert context.index("<metadata>") < context.index("<messages>")
+        assert "current_time:" not in context
+        assert "harness_will_reverse_output:" not in context
+
     def test_ai_request_places_volatile_metadata_after_context(self):
         context = "<context>\n<messages>old</messages>\n</context>"
 

--- a/tests/test_tob.py
+++ b/tests/test_tob.py
@@ -4,7 +4,7 @@ from typing import Any
 from dotenv import load_dotenv
 import discord
 
-from src.tob import AI_REQUEST_FAILED, DISCORD_MESSAGE_MAX_LENGTH, Tob
+from src.tob import AI_REQUEST_FAILED, DISCORD_MESSAGE_MAX_LENGTH, AiContextMessage, Tob
 from src.utils.utils import *
 from src.utils.log import *
 
@@ -111,9 +111,11 @@ class TestTob:
 
     def test_ai_context_messages_use_extra_author_info_once(self):
         context = [
-            (1.0, "channel", 1, "123", "display", "username id=123", "hello <world>"),
-            (2.0, "channel", 2, "123", "display", "username id=123", "again"),
-            (3.0, "channel", 3, "456", "other", "id=456", "bye"),
+            AiContextMessage(
+                1.0, "channel", 1, "123", "display", "username id=123", "hello <world>"
+            ),
+            AiContextMessage(2.0, "channel", 2, "123", "display", "username id=123", "again"),
+            AiContextMessage(3.0, "channel", 3, "456", "other", "id=456", "bye"),
         ]
 
         messages = self.tob._format_ai_context_messages(context)
@@ -127,13 +129,13 @@ class TestTob:
 
     def test_ai_context_removes_deleted_messages(self):
         self.tob.ai_message_context = [
-            (1.0, "channel", 1, "author", "author", "", "one"),
-            (2.0, "channel", 2, "author", "author", "", "two"),
-            (3.0, "channel", 3, "author", "author", "", "three"),
+            AiContextMessage(1.0, "channel", 1, "author", "author", "", "one"),
+            AiContextMessage(2.0, "channel", 2, "author", "author", "", "two"),
+            AiContextMessage(3.0, "channel", 3, "author", "author", "", "three"),
         ]
 
         self.tob._remove_ai_context_message(2)
-        assert [x[2] for x in self.tob.ai_message_context] == [1, 3]
+        assert [x.message_id for x in self.tob.ai_message_context] == [1, 3]
 
         self.tob._remove_ai_context_messages({1, 3})
         assert self.tob.ai_message_context == []
@@ -147,12 +149,14 @@ class TestTob:
             attachments = []
             reference = None
 
-        self.tob.ai_message_context = [(1.0, "channel", 1, "author", "author", "", "old")]
+        self.tob.ai_message_context = [
+            AiContextMessage(1.0, "channel", 1, "author", "author", "", "old")
+        ]
 
         self.tob._update_ai_context_message(Message(), "new <text>")
 
         assert self.tob.ai_message_context == [
-            (1.0, "channel", 1, "author", "author", "", "new <text>")
+            AiContextMessage(1.0, "channel", 1, "author", "author", "", "new <text>")
         ]
 
     def test_ai_reply_retries_missing_content(self, monkeypatch):

--- a/tests/test_tob.py
+++ b/tests/test_tob.py
@@ -89,6 +89,42 @@ class TestTob:
 
         assert self.tob._get_ai_query(msg, msg.content) == "hello"
 
+    def test_ai_mentions_use_display_name_without_discriminator(self):
+        class User:
+            id = 123
+            name = "username"
+            display_name = "display"
+
+            def __str__(self):
+                return "username#1234"
+
+        class Message:
+            mentions = [User()]
+            channel_mentions = []
+            attachments = []
+            reference = None
+
+        assert (
+            self.tob._format_ai_text(Message(), "hi <@123> and <@!123>")
+            == "hi @display and @display"
+        )
+
+    def test_ai_context_messages_use_extra_author_info_once(self):
+        context = [
+            (1.0, "channel", 1, "123", "display", "username id=123", "hello <world>"),
+            (2.0, "channel", 2, "123", "display", "username id=123", "again"),
+            (3.0, "channel", 3, "456", "other", "id=456", "bye"),
+        ]
+
+        messages = self.tob._format_ai_context_messages(context)
+
+        assert (
+            '<message id="1" author="display (username id=123)">\nhello &lt;world&gt;\n</message>'
+            in messages
+        )
+        assert '<message id="2" author="display">\nagain\n</message>' in messages
+        assert '<message id="3" author="other (id=456)">\nbye\n</message>' in messages
+
     def test_ai_reply_retries_missing_content(self, monkeypatch):
         calls = 0
 

--- a/tests/test_tob.py
+++ b/tests/test_tob.py
@@ -159,6 +159,15 @@ class TestTob:
             AiContextMessage(1.0, "channel", 1, "author", "author", "", "new <text>")
         ]
 
+    def test_ai_request_places_volatile_metadata_after_context(self):
+        context = "<context>\n<messages>old</messages>\n</context>"
+
+        content = self.tob._format_ai_request_content("hi", "author", context, True)
+
+        assert content.startswith(context)
+        assert content.index("current_time:") > content.index("</context>")
+        assert "harness_will_reverse_output: true" in content
+
     def test_ai_reply_retries_missing_content(self, monkeypatch):
         calls = 0
 


### PR DESCRIPTION
This changes AI context rendering to pass prior messages as explicit XML-like `<message>` objects with escaped content and message ids.

Author metadata is compacted per context: the first message from an author includes the display name plus username/id details, while later messages from the same author use only the display name. Mention expansion also uses display names without Discord discriminators so prompts stay shorter and less noisy.

The in-memory context is kept fresh when Discord messages are edited or deleted, including bulk deletes, so stale deleted or edited content is not reused until the normal context age cutoff.

Prompt ordering is adjusted for provider prompt caching: stable context metadata comes before messages, volatile request metadata comes after context, and OpenRouter `session_id` is set per Discord channel for sticky routing. Cache usage details are logged when OpenRouter returns them.
